### PR TITLE
Remove support for MFA :with option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ add(:channel, :map)
 
 * `:required` – if the embed is a required field.
 
-* `:with` – allows you to specify a custom changeset. Either pass an MFA or a function:
+* `:with` – allows you to specify a custom changeset.
 ```elixir
 changeset
 |> cast_polymorphic_embed(:channel,
   with: [
-    sms: {SMS, :custom_changeset, ["hello"]},
+    sms: &SMS.custom_changeset/2,
     email: &Email.custom_changeset/2
   ]
 )

--- a/test/polymorphic_embed_test.exs
+++ b/test/polymorphic_embed_test.exs
@@ -682,7 +682,7 @@ defmodule PolymorphicEmbedTest do
     end
   end
 
-  test "custom changeset by passing MFA" do
+  test "custom changeset by passing function" do
     for generator <- @generators do
       reminder_module = get_module(Reminder, generator)
       sms_module = get_module(Channel.SMS, generator)
@@ -719,43 +719,6 @@ defmodule PolymorphicEmbedTest do
     end
   end
 
-  test "custom changeset by passing function" do
-    for generator <- @generators do
-      reminder_module = get_module(Reminder, generator)
-      sms_module = get_module(Channel.SMS, generator)
-
-      sms_reminder_attrs = %{
-        date: ~U[2020-05-28 02:57:19Z],
-        text: "This is an SMS reminder #{generator}",
-        channel: %{
-          my_type_field: "sms",
-          number: "02/807.05.53",
-          country_code: 1,
-          attempts: [],
-          provider: %{__type__: "twilio", api_key: "somekey"},
-          custom: true
-        }
-      }
-
-      insert_result =
-        struct(reminder_module)
-        |> reminder_module.custom_changeset2(sms_reminder_attrs)
-        |> Repo.insert()
-
-      assert {:ok, reminder} = insert_result
-      assert reminder.channel.custom
-
-      %reminder_module{} = reminder
-
-      reminder =
-        reminder_module
-        |> QueryBuilder.where(text: "This is an SMS reminder #{generator}")
-        |> Repo.one()
-
-      assert sms_module == reminder.channel.__struct__
-    end
-  end
-
   test "with option but not for all" do
     generator = :polymorphic
     reminder_module = get_module(Reminder, generator)
@@ -774,7 +737,7 @@ defmodule PolymorphicEmbedTest do
 
     insert_result =
       struct(reminder_module)
-      |> reminder_module.custom_changeset2(sms_reminder_attrs)
+      |> reminder_module.custom_changeset(sms_reminder_attrs)
       |> Repo.insert()
 
     assert {:ok, reminder} = insert_result

--- a/test/support/models/not_polymorphic/channel/sms.ex
+++ b/test/support/models/not_polymorphic/channel/sms.ex
@@ -23,13 +23,7 @@ defmodule PolymorphicEmbed.Regular.Channel.SMS do
     |> validate_required([:number, :country_code])
   end
 
-  def custom_changeset(struct, attrs, _foo, _bar) do
-    struct
-    |> changeset(attrs)
-    |> cast(attrs, [:custom])
-  end
-
-  def custom_changeset2(struct, attrs) do
+  def custom_changeset(struct, attrs) do
     struct
     |> changeset(attrs)
     |> cast(attrs, [:custom])

--- a/test/support/models/not_polymorphic/reminder.ex
+++ b/test/support/models/not_polymorphic/reminder.ex
@@ -27,16 +27,7 @@ defmodule PolymorphicEmbed.Regular.Reminder do
   def custom_changeset(struct, values) do
     struct
     |> cast(values, [:date, :text])
-    |> cast_embed(:channel,
-      with: {PolymorphicEmbed.Regular.Channel.SMS, :custom_changeset, ["foo", "bar"]}
-    )
-    |> validate_required(:date)
-  end
-
-  def custom_changeset2(struct, values) do
-    struct
-    |> cast(values, [:date, :text])
-    |> cast_embed(:channel, with: &PolymorphicEmbed.Regular.Channel.SMS.custom_changeset2/2)
+    |> cast_embed(:channel, with: &PolymorphicEmbed.Regular.Channel.SMS.custom_changeset/2)
     |> validate_required(:date)
   end
 end

--- a/test/support/models/polymorphic/channel/sms.ex
+++ b/test/support/models/polymorphic/channel/sms.ex
@@ -41,13 +41,7 @@ defmodule PolymorphicEmbed.Channel.SMS do
     |> validate_required([:number, :country_code])
   end
 
-  def custom_changeset(struct, attrs, _foo, _bar) do
-    struct
-    |> changeset(attrs)
-    |> cast(attrs, [:custom])
-  end
-
-  def custom_changeset2(struct, attrs) do
+  def custom_changeset(struct, attrs) do
     struct
     |> changeset(attrs)
     |> cast(attrs, [:custom])

--- a/test/support/models/polymorphic/reminder.ex
+++ b/test/support/models/polymorphic/reminder.ex
@@ -56,30 +56,7 @@ defmodule PolymorphicEmbed.Reminder do
     |> cast(values, [:date, :text])
     |> cast_polymorphic_embed(:channel,
       with: [
-        sms: {PolymorphicEmbed.Channel.SMS, :custom_changeset, ["foo", "bar"]},
-        email: {PolymorphicEmbed.Channel.Email, :custom_changeset, ["foo", "bar"]}
-      ]
-    )
-    |> validate_required(:date)
-  end
-
-  def custom_changeset2(struct, values) do
-    struct
-    |> cast(values, [:date, :text])
-    |> cast_polymorphic_embed(:channel,
-      with: [
-        sms: &PolymorphicEmbed.Channel.SMS.custom_changeset2/2
-      ]
-    )
-    |> validate_required(:date)
-  end
-
-  def custom_changeset3(struct, values) do
-    struct
-    |> cast(values, [:date, :text])
-    |> cast_polymorphic_embed(:channel,
-      with: [
-        sms: &PolymorphicEmbed.Channel.SMS.custom_changeset2/2
+        sms: &PolymorphicEmbed.Channel.SMS.custom_changeset/2
       ]
     )
     |> validate_required(:date)


### PR DESCRIPTION
* ecto 3.10+ has deprecated passing an MFA into :with, so we will no longer officially support it
* in removing the accompanying test, i was able to rename and delete unused changeset funcs