### PR TITLE
Support retaining ids on `cast_polymorphic_embed` for `polymorphic_embeds_many`

### DIFF
--- a/lib/polymorphic_embed.ex
+++ b/lib/polymorphic_embed.ex
@@ -264,8 +264,12 @@ defmodule PolymorphicEmbed do
 
           module ->
             data_for_field =
-              Enum.find(list_data_for_field, fn datum ->
-                datum.id != nil and datum.id == params[:id] and datum.__struct__ == module
+              Enum.find(list_data_for_field, fn
+                %{id: id} = datum when not is_nil(id) ->
+                  id == params[:id] and datum.__struct__ == module
+
+                _ ->
+                  nil
               end)
 
             embed_changeset =

--- a/test/polymorphic_embed_test.exs
+++ b/test/polymorphic_embed_test.exs
@@ -1217,6 +1217,32 @@ defmodule PolymorphicEmbedTest do
 
       assert Enum.at(reminder.contexts, 0).id != Enum.at(updated_reminder.contexts, 0).id
       assert Enum.at(reminder.contexts, 1).id != Enum.at(updated_reminder.contexts, 1).id
+
+      # Assert that we have same ids when the provided context element has an id
+      attrs = %{
+        contexts: [
+          %{
+            __type__: "device",
+            id: Enum.at(reminder.contexts, 0).id,
+            ref: "12345",
+            type: "cellphone",
+            address: "address"
+          },
+          %{
+            __type__: "age",
+            age: "aquarius",
+            address: "address"
+          }
+        ]
+      }
+
+      updated_reminder =
+        reminder
+        |> reminder_module.changeset(attrs)
+        |> Repo.update!()
+
+      assert Enum.at(reminder.contexts, 0).id == Enum.at(updated_reminder.contexts, 0).id
+      assert Enum.at(reminder.contexts, 1).id != Enum.at(updated_reminder.contexts, 1).id
     end
   end
 


### PR DESCRIPTION
Right now `cast_polymorphic_embed` for `polymorphic_embeds_many`, only creates new structs from the "module" and ignores the data (possibly with id) provided (normally the first argument of a changeset/2 function). This leads to creating new ids for each and every update when it's not required and not desired in some cases. This MR fixes this. This is the way a non-polymorphic `cast_embed` for `embeds_many` behaves right now.
